### PR TITLE
Update make.ngrams.R

### DIFF
--- a/R/make.ngrams.R
+++ b/R/make.ngrams.R
@@ -22,7 +22,7 @@ function(input.text,ngram.size=1) {
     txt = input.text
     for(n in 2:ngram.size) {
     # agglutinating subsequent words/chars into n-grams
-    txt = paste(txt[1:(length(txt)-1)],input.text[n:length(input.text)])
+    txt = stri_paste(txt[1:(length(txt)-1)],input.text[n:length(input.text)],sep = " ")
     }
   } else {
   # if n-gram size is set to 1, then nothing will happen


### PR DESCRIPTION
Changed the `paste` function to `stri_paste` function from the `stringi` package (available on CRAN). The `stri_paste` function is substantially faster than paste function, which is beneficial when making ngrams from large `input.text`.
`stringi` package should be loaded by the `stylo` package. I advise changing `paste` to `stri_paste` in other functions as well.
